### PR TITLE
Use plone.app.testing facilities

### DIFF
--- a/flake8_deprecated.py
+++ b/flake8_deprecated.py
@@ -18,6 +18,7 @@ class Flake8Deprecated(object):
         'AccessControl.ClassSecurityInfo.public': ('declarePublic', ),
         'zope.interface.provider': ('directlyProvides', ),
         'zope.interface.implementer': ('classImplements', ),
+        'xmlconfig.file(': ('self.loadZCML', ),
     }
 
     def __init__(self, tree, filename):


### PR DESCRIPTION
plone.app.testing has already a way to load ZCML files from packages,
so there's no need to import zope.configuration and its xmlconfig method.
