### PR TITLE
Use ast to parse the tree

### DIFF
--- a/flake8_deprecated.py
+++ b/flake8_deprecated.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-try:
-    from flake8.engine import pep8 as stdin_utils
-except ImportError:
-    from flake8 import utils as stdin_utils
+import ast
 
 
 class Flake8Deprecated(object):
@@ -10,40 +7,34 @@ class Flake8Deprecated(object):
     version = '1.2'
     message = 'D001 found {0:s} replace it with {1:s}'
     checks = {
-        'assertEqual': ('failUnlessEqual(', 'assertEquals(', ),
-        'assertNotEqual': ('failIfEqual(', ),
-        'assertTrue': ('failUnless(', 'assert_(', ),
-        'assertFalse': ('failIf(', ),
-        'assertRaises': ('failUnlessRaises(', ),
-        'assertAlmostEqual': ('failUnlessAlmostEqual(', ),
-        'assertNotAlmostEqual': ('failIfAlmostEqual(', ),
-        'AccessControl.ClassSecurityInfo.protected': ('declareProtected(', ),
-        'AccessControl.ClassSecurityInfo.private': ('declarePrivate(', ),
-        'AccessControl.ClassSecurityInfo.public': ('declarePublic(', ),
-        'zope.interface.provider': ('directlyProvides(', ),
-        'zope.interface.implementer': ('classImplements(', ),
-        'self.loadZCML(': ('xmlconfig.file(', ),
-        'zope.interface.implementer': ('implements(', ),
-        'zope.component.adapter': ('adapts(', ),
+        'assertEqual': ('failUnlessEqual', 'assertEquals', ),
+        'assertNotEqual': ('failIfEqual', ),
+        'assertTrue': ('failUnless', 'assert_', ),
+        'assertFalse': ('failIf', ),
+        'assertRaises': ('failUnlessRaises', ),
+        'assertAlmostEqual': ('failUnlessAlmostEqual', ),
+        'assertNotAlmostEqual': ('failIfAlmostEqual', ),
+        'AccessControl.ClassSecurityInfo.protected': ('declareProtected', ),
+        'AccessControl.ClassSecurityInfo.private': ('declarePrivate', ),
+        'AccessControl.ClassSecurityInfo.public': ('declarePublic', ),
+        'zope.interface.provider': ('directlyProvides', ),
+        'zope.interface.implementer': ('classImplements', ),
+        'self.loadZCML(': ('xmlconfig.file', ),
+        'zope.interface.implementer': ('implements', ),
+        'zope.component.adapter': ('adapts', ),
     }
 
-    def __init__(self, tree, filename):
-        self.filename = filename
+    def __init__(self, tree):
         self.flat_checks = self._flatten_checks()
+        self.tree = tree
 
     def run(self):
-        if self.filename == 'stdin':
-            lines = stdin_utils.stdin_get_value().splitlines(True)
-        else:
-            with open(self.filename, 'rb') as f:
-                lines = [line.decode('utf-8') for line in f.readlines()]
-
-        for lineno, line in enumerate(lines, start=1):
-            for newer_version, old_alias in self.flat_checks:
-                position = line.find(old_alias)
-                if position != -1:
-                    msg = self.message.format(old_alias, newer_version)
-                    yield lineno, position, msg, type(self)
+        for node in ast.walk(self.tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                for newer_version, old_alias in self.flat_checks:
+                    if node.func.attr == old_alias:
+                        msg = self.message.format(old_alias, newer_version)
+                        yield node.lineno, node.col_offset, msg, type(self)
 
     def _flatten_checks(self):
         flattened_checks = []

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,45 +1,51 @@
 # -*- coding: utf-8 -*-
 from flake8_deprecated import Flake8Deprecated
-from tempfile import mkdtemp
 
-import os
+import ast
 import unittest
 
 
 class TestFlake8Deprecated(unittest.TestCase):
 
-    def _given_a_file_in_test_dir(self, contents):
-        test_dir = os.path.realpath(mkdtemp())
-        file_path = os.path.join(test_dir, 'test.py')
-        with open(file_path, 'w') as a_file:
-            a_file.write(contents)
-
-        return file_path
+    def _given_test_data(self, contents):
+        return ast.parse(contents)
 
     def test_no_deprecations_all_good(self):
-        file_path = self._given_a_file_in_test_dir('\n'.join([
+        tree = self._given_test_data('\n'.join([
             'b = 3',
             'b.lower()',
         ]))
-        checker = Flake8Deprecated(None, file_path)
+        checker = Flake8Deprecated(tree)
         ret = list(checker.run())
         self.assertEqual(len(ret), 0)
 
     def test_s_formatter(self):
-        file_path = self._given_a_file_in_test_dir('\n'.join([
+        tree = self._given_test_data('\n'.join([
             'import unittest',
             'unittest.failUnlessAlmostEqual()',
         ]))
-        checker = Flake8Deprecated(None, file_path)
+        checker = Flake8Deprecated(tree)
         ret = list(checker.run())
         self.assertEqual(len(ret), 1)
         self.assertEqual(ret[0][0], 2)
-        self.assertEqual(ret[0][1], 9)
+        self.assertEqual(ret[0][1], 0)
         self.assertEqual(
             ret[0][2],
-            'D001 found failUnlessAlmostEqual( replace it with '
+            'D001 found failUnlessAlmostEqual replace it with '
             'assertAlmostEqual'
         )
+
+    def test_ignores_comments(self):
+        tree = self._given_test_data('\n'.join([
+            'import unittest',
+            '# Maybe we could use assertEquals() here?',
+            'unittest.assertEquals()',
+        ]))
+        checker = Flake8Deprecated(tree)
+        ret = list(checker.run())
+        self.assertEqual(len(ret), 1)
+        lint_line_number = ret[0][0]
+        self.assertEqual(lint_line_number, 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This has the benefit that we ensure it only checks actual function calls.

As far as I can tell this means we don't need the filename at all anymore.

The reason one of the tests has changed the column offset from 9 to 0 is that the tree measures offsets in a different way to the string matching.

I've followed the pattern from flake8-pytest quite closely in this commit: https://github.com/vikingco/flake8-pytest/blob/c6861968d7ee8fd9680343f6bae5fb/flake8_pytest.py

Fixes #6.